### PR TITLE
Experimental error checker trait

### DIFF
--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -3381,7 +3381,7 @@ impl<'alloc> AstBuilder<'alloc> {
         let label_loc = label.loc;
         let body_loc = body.get_loc();
         self.mark_labelled_statement(&label, &body);
-        self.check_labelled_statement(label.value, label_loc.start, label_loc.end)?;
+        self.check_labelled_statement(label.value, label_loc.start, body_loc.start)?;
         Ok(self.alloc_with(|| Statement::LabelledStatement {
             label: label.unbox(),
             body,

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -2710,9 +2710,9 @@ impl<'alloc> AstBuilder<'alloc> {
         consequent: arena::Box<'alloc, Statement<'alloc>>,
         alternate: Option<arena::Box<'alloc, Statement<'alloc>>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&consequent)?;
+        self.check_single_statement(consequent.get_loc().start)?;
         if let Some(ref stmt) = alternate {
-            self.check_single_statement(&stmt)?;
+            self.check_single_statement(stmt.get_loc().start)?;
         }
 
         let if_loc = if_token.loc;
@@ -2779,7 +2779,7 @@ impl<'alloc> AstBuilder<'alloc> {
         test: arena::Box<'alloc, Expression<'alloc>>,
         close_token: arena::Box<'alloc, Token>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
 
         self.context_metadata
             .pop_unlabelled_breaks_and_continues_from(do_token.loc.start);
@@ -2797,7 +2797,7 @@ impl<'alloc> AstBuilder<'alloc> {
         test: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
 
         let stmt_loc = stmt.get_loc();
         self.context_metadata
@@ -2819,7 +2819,7 @@ impl<'alloc> AstBuilder<'alloc> {
         update: Option<arena::Box<'alloc, Expression<'alloc>>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.for_statement_common(for_token, init, test, update, stmt)
     }
 
@@ -2832,7 +2832,7 @@ impl<'alloc> AstBuilder<'alloc> {
         update: Option<arena::Box<'alloc, Expression<'alloc>>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.check_lexical_for_bindings(&init.get_loc())?;
         self.for_statement_common(for_token, Some(init), test, update, stmt)
     }
@@ -2909,7 +2909,7 @@ impl<'alloc> AstBuilder<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.for_in_statement_common(for_token, left, right, stmt)
     }
 
@@ -2921,7 +2921,7 @@ impl<'alloc> AstBuilder<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.check_lexical_for_bindings(&left.get_loc())?;
         self.for_in_statement_common(for_token, left, right, stmt)
     }
@@ -2999,7 +2999,7 @@ impl<'alloc> AstBuilder<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.for_of_statement_common(for_token, left, right, stmt)
     }
 
@@ -3011,7 +3011,7 @@ impl<'alloc> AstBuilder<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.check_lexical_for_bindings(&left.get_loc())?;
         self.for_of_statement_common(for_token, left, right, stmt)
     }
@@ -3043,7 +3043,7 @@ impl<'alloc> AstBuilder<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.for_await_of_statement_common(for_token, left, right, stmt)
     }
 
@@ -3055,7 +3055,7 @@ impl<'alloc> AstBuilder<'alloc> {
         right: arena::Box<'alloc, Expression<'alloc>>,
         stmt: arena::Box<'alloc, Statement<'alloc>>,
     ) -> Result<'alloc, arena::Box<'alloc, Statement<'alloc>>> {
-        self.check_single_statement(&stmt)?;
+        self.check_single_statement(stmt.get_loc().start)?;
         self.check_lexical_for_bindings(&left.get_loc())?;
         self.for_await_of_statement_common(for_token, left, right, stmt)
     }
@@ -4997,53 +4997,6 @@ impl<'alloc> AstBuilder<'alloc> {
         true
     }
 
-    // Static Semantics: Early Errors
-    // https://tc39.es/ecma262/#sec-if-statement-static-semantics-early-errors
-    // https://tc39.es/ecma262/#sec-semantics-static-semantics-early-errors
-    // https://tc39.es/ecma262/#sec-with-statement-static-semantics-early-errors
-    fn check_single_statement(
-        &self,
-        stmt: &arena::Box<'alloc, Statement<'alloc>>,
-    ) -> Result<'alloc, ()> {
-        // * It is a Syntax Error if IsLabelledFunction(Statement) is true.
-        if self.is_labelled_function(stmt) {
-            return Err(ParseError::LabelledFunctionDeclInSingleStatement.into());
-        }
-        Ok(())
-    }
-
-    // https://tc39.es/ecma262/#sec-islabelledfunction
-    // Static Semantics: IsLabelledFunction ( stmt )
-    //
-    // Returns IsLabelledFunction of `stmt`.
-    //
-    // NOTE: For Syntax-only parsing (NYI), the stack value for Statement
-    //       should contain this information.
-    fn is_labelled_function(&self, stmt: &Statement<'alloc>) -> bool {
-        // Step 1. If stmt is not a LabelledStatement , return false.
-        if let Some(index) = self
-            .context_metadata
-            .find_label_index_at_offset(stmt.get_loc().start)
-        {
-            // Step 2. Let item be the LabelledItem of stmt.
-            for label in self.context_metadata.labels_from(index) {
-                match label.kind {
-                    // Step 3. If item is LabelledItem : FunctionDeclaration,
-                    // return true.
-                    LabelKind::Function => {
-                        return true;
-                    }
-                    // Step 4. Let subStmt be the Statement of item.
-                    // Step 5. Return IsLabelledFunction(subStmt).
-                    LabelKind::LabelledLabel => continue,
-                    _ => break,
-                }
-            }
-        }
-
-        false
-    }
-
     fn mark_labelled_statement(
         &mut self,
         label: &arena::Box<'alloc, Label>,
@@ -5069,5 +5022,8 @@ impl<'alloc> AstBuilder<'alloc> {
 impl<'alloc> EarlyErrorChecker<'alloc> for AstBuilder<'alloc> {
     fn context_metadata(&mut self) -> &mut ContextMetadata {
         &mut self.context_metadata
+    }
+    fn context_metadata_immutable(&self) -> &ContextMetadata {
+        &self.context_metadata
     }
 }

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -4912,10 +4912,10 @@ impl<'alloc> AstBuilder<'alloc> {
 }
 
 impl<'alloc> EarlyErrorChecker<'alloc> for AstBuilder<'alloc> {
-    fn context_metadata(&mut self) -> &mut ContextMetadata {
+    fn context_metadata_mut(&mut self) -> &mut ContextMetadata {
         &mut self.context_metadata
     }
-    fn context_metadata_immutable(&self) -> &ContextMetadata {
+    fn context_metadata(&self) -> &ContextMetadata {
         &self.context_metadata
     }
     fn atoms(&self) -> &Rc<RefCell<SourceAtomSet<'alloc>>> {

--- a/crates/generated_parser/src/ast_builder.rs
+++ b/crates/generated_parser/src/ast_builder.rs
@@ -4804,22 +4804,6 @@ impl<'alloc> AstBuilder<'alloc> {
         Ok(())
     }
 
-    fn check_unhandled_break_or_continue<T>(
-        &mut self,
-        context: T,
-        offset: usize,
-    ) -> Result<'alloc, ()>
-    where
-        T: ControlEarlyErrorsContext,
-    {
-        let index = self.context_metadata.find_first_break_or_continue(offset);
-        if let Some(info) = self.context_metadata.find_break_or_continue_at(index) {
-            context.on_unhandled_break_or_continue(info)?;
-        }
-
-        Ok(())
-    }
-
     // Declare bindings to script-or-function-like context, where function
     // declarations are body-level.
     fn declare_script_or_function<T>(

--- a/crates/generated_parser/src/early_error_checker.rs
+++ b/crates/generated_parser/src/early_error_checker.rs
@@ -1,0 +1,64 @@
+use crate::context_stack::{BreakOrContinueIndex, ContextMetadata};
+use crate::early_errors::*;
+use crate::error::Result;
+use ast::source_atom_set::SourceAtomSetIndex;
+
+pub trait EarlyErrorChecker<'alloc> {
+    fn context_metadata(&mut self) -> &mut ContextMetadata;
+    fn check_labelled_statement(
+        &mut self,
+        name: SourceAtomSetIndex,
+        start_label_offset: usize,
+        end_label_offset: usize,
+    ) -> Result<'alloc, ()> {
+        let label = self
+            .context_metadata()
+            .find_label_at_offset(start_label_offset)
+            .unwrap();
+
+        let context = LabelledStatementEarlyErrorsContext::new(name, label.kind);
+        let next_label_index = self.context_metadata().find_first_label(end_label_offset);
+        for info in self.context_metadata().labels_from(next_label_index) {
+            context.check_duplicate_label(info.name)?;
+        }
+
+        let break_or_continue_index = self
+            .context_metadata()
+            .find_first_break_or_continue(start_label_offset);
+
+        self.check_unhandled_continue(context, break_or_continue_index)?;
+
+        self.context_metadata()
+            .pop_labelled_breaks_and_continues_from_index(break_or_continue_index, name);
+        Ok(())
+    }
+
+    fn check_unhandled_continue(
+        &mut self,
+        context: LabelledStatementEarlyErrorsContext,
+        index: BreakOrContinueIndex,
+    ) -> Result<'alloc, ()> {
+        for info in self.context_metadata().breaks_and_continues_from(index) {
+            context.check_labelled_continue_to_non_loop(info)?;
+        }
+
+        Ok(())
+    }
+
+    fn check_unhandled_break_or_continue<T>(
+        &self,
+        context_metadata: &mut ContextMetadata,
+        context: T,
+        offset: usize,
+    ) -> Result<'alloc, ()>
+    where
+        T: ControlEarlyErrorsContext,
+    {
+        let index = context_metadata.find_first_break_or_continue(offset);
+        if let Some(info) = context_metadata.find_break_or_continue_at(index) {
+            context.on_unhandled_break_or_continue(info)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/generated_parser/src/early_error_checker.rs
+++ b/crates/generated_parser/src/early_error_checker.rs
@@ -47,16 +47,15 @@ pub trait EarlyErrorChecker<'alloc> {
     }
 
     fn check_unhandled_break_or_continue<T>(
-        &self,
-        context_metadata: &mut ContextMetadata,
+        &mut self,
         context: T,
         offset: usize,
     ) -> Result<'alloc, ()>
     where
         T: ControlEarlyErrorsContext,
     {
-        let index = context_metadata.find_first_break_or_continue(offset);
-        if let Some(info) = context_metadata.find_break_or_continue_at(index) {
+        let index = self.context_metadata().find_first_break_or_continue(offset);
+        if let Some(info) = self.context_metadata().find_break_or_continue_at(index) {
             context.on_unhandled_break_or_continue(info)?;
         }
 

--- a/crates/generated_parser/src/early_error_checker.rs
+++ b/crates/generated_parser/src/early_error_checker.rs
@@ -15,60 +15,30 @@ pub trait EarlyErrorChecker<'alloc> {
     fn check_labelled_statement(
         &mut self,
         name: SourceAtomSetIndex,
-        start_label_offset: usize,
-        end_label_offset: usize,
+        label_offset: usize,
+        statement_offset: usize,
     ) -> Result<'alloc, ()> {
         let label = self
             .context_metadata_mut()
-            .find_label_at_offset(start_label_offset)
+            .find_label_at_offset(label_offset)
             .unwrap();
 
         let context = LabelledStatementEarlyErrorsContext::new(name, label.kind);
         let next_label_index = self
             .context_metadata_mut()
-            .find_first_label(end_label_offset);
+            .find_first_label(statement_offset);
         for info in self.context_metadata_mut().labels_from(next_label_index) {
             context.check_duplicate_label(info.name)?;
         }
 
         let break_or_continue_index = self
             .context_metadata_mut()
-            .find_first_break_or_continue(start_label_offset);
+            .find_first_break_or_continue(label_offset);
 
-        self.check_unhandled_continue(context, break_or_continue_index)?;
+        self.internal_check_unhandled_continue(context, break_or_continue_index)?;
 
         self.context_metadata_mut()
             .pop_labelled_breaks_and_continues_from_index(break_or_continue_index, name);
-        Ok(())
-    }
-
-    fn check_unhandled_continue(
-        &mut self,
-        context: LabelledStatementEarlyErrorsContext,
-        index: BreakOrContinueIndex,
-    ) -> Result<'alloc, ()> {
-        for info in self.context_metadata_mut().breaks_and_continues_from(index) {
-            context.check_labelled_continue_to_non_loop(info)?;
-        }
-
-        Ok(())
-    }
-
-    fn check_unhandled_break_or_continue<T>(
-        &mut self,
-        context: T,
-        offset: usize,
-    ) -> Result<'alloc, ()>
-    where
-        T: ControlEarlyErrorsContext,
-    {
-        let index = self
-            .context_metadata_mut()
-            .find_first_break_or_continue(offset);
-        if let Some(info) = self.context_metadata_mut().find_break_or_continue_at(index) {
-            context.on_unhandled_break_or_continue(info)?;
-        }
-
         Ok(())
     }
 
@@ -76,9 +46,9 @@ pub trait EarlyErrorChecker<'alloc> {
     // https://tc39.es/ecma262/#sec-if-statement-static-semantics-early-errors
     // https://tc39.es/ecma262/#sec-semantics-static-semantics-early-errors
     // https://tc39.es/ecma262/#sec-with-statement-static-semantics-early-errors
-    fn check_single_statement(&self, offset: usize) -> Result<'alloc, ()> {
+    fn check_single_statement(&self, statement_start_offset: usize) -> Result<'alloc, ()> {
         // * It is a Syntax Error if IsLabelledFunction(Statement) is true.
-        if self.is_labelled_function(offset) {
+        if self.is_labelled_function(statement_start_offset) {
             return Err(ParseError::LabelledFunctionDeclInSingleStatement.into());
         }
         Ok(())
@@ -91,9 +61,12 @@ pub trait EarlyErrorChecker<'alloc> {
     //
     // NOTE: For Syntax-only parsing (NYI), the stack value for Statement
     //       should contain this information.
-    fn is_labelled_function(&self, offset: usize) -> bool {
+    fn is_labelled_function(&self, statement_start_offset: usize) -> bool {
         // Step 1. If stmt is not a LabelledStatement , return false.
-        if let Some(index) = self.context_metadata().find_label_index_at_offset(offset) {
+        if let Some(index) = self
+            .context_metadata()
+            .find_label_index_at_offset(statement_start_offset)
+        {
             // Step 2. Let item be the LabelledItem of stmt.
             for label in self.context_metadata().labels_from(index) {
                 match label.kind {
@@ -113,7 +86,9 @@ pub trait EarlyErrorChecker<'alloc> {
         false
     }
 
-    // Check bindings in Script.
+    // Check bindings in Script. This is called after we have identified that
+    // we are in a script. Any remaining bindings should be legal in this context.
+    // Any labels within this context are only valid here, and can be popped.
     fn check_script_bindings(&mut self) -> Result<'alloc, ()> {
         let mut context = ScriptEarlyErrorsContext::new();
         let index = BindingsIndex { index: 0 };
@@ -128,7 +103,9 @@ pub trait EarlyErrorChecker<'alloc> {
         Ok(())
     }
 
-    // Check bindings in Module.
+    // Check bindings in Module. This is called after we have identified that
+    // we are in a Module. Any remaining bindings should be legal in this context.
+    // Any labels within this context are only valid here, and can be popped.
     fn check_module_bindings(&mut self) -> Result<'alloc, ()> {
         let mut context = ModuleEarlyErrorsContext::new();
         let index = BindingsIndex { index: 0 };
@@ -143,8 +120,49 @@ pub trait EarlyErrorChecker<'alloc> {
         Ok(())
     }
 
-    // Declare bindings to script-or-function-like context, where function
-    // declarations are body-level.
+    /// Internal helper method:
+    /// called From EarlyErrorChecker::check_labelled_statement, and not used by
+    /// the struct implementing the trait. This means that
+    /// LabelledStatementEarlyErrorsContext is allocated inside this trait.
+    fn internal_check_unhandled_continue(
+        &mut self,
+        context: LabelledStatementEarlyErrorsContext,
+        index: BreakOrContinueIndex,
+    ) -> Result<'alloc, ()> {
+        for info in self.context_metadata_mut().breaks_and_continues_from(index) {
+            context.check_labelled_continue_to_non_loop(info)?;
+        }
+
+        Ok(())
+    }
+
+    /// Internal helper method:
+    /// called From EarlyErrorChecker::check_script_bindings
+    /// EarlyErrorChecker::check_module_bindings,
+    /// EarlyErrorChecker::check_function_bindings, and not used by
+    /// the struct implementing the trait. This means that
+    /// the contexts associated with those methods are allocated inside this trait.
+    fn check_unhandled_break_or_continue<T>(
+        &mut self,
+        context: T,
+        offset: usize,
+    ) -> Result<'alloc, ()>
+    where
+        T: ControlEarlyErrorsContext,
+    {
+        let index = self
+            .context_metadata_mut()
+            .find_first_break_or_continue(offset);
+        if let Some(info) = self.context_metadata_mut().find_break_or_continue_at(index) {
+            context.on_unhandled_break_or_continue(info)?;
+        }
+
+        Ok(())
+    }
+
+    /// Declare bindings in context_metadata to script-or-function-like context,
+    /// where function declarations are body-level. This method is an internal
+    /// helper for EarlyErrorChecker
     fn declare_script_or_function<T>(
         &mut self,
         context: &mut T,

--- a/crates/generated_parser/src/early_error_checker.rs
+++ b/crates/generated_parser/src/early_error_checker.rs
@@ -9,8 +9,8 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 pub trait EarlyErrorChecker<'alloc> {
-    fn context_metadata(&mut self) -> &mut ContextMetadata;
-    fn context_metadata_immutable(&self) -> &ContextMetadata;
+    fn context_metadata_mut(&mut self) -> &mut ContextMetadata;
+    fn context_metadata(&self) -> &ContextMetadata;
     fn atoms(&self) -> &Rc<RefCell<SourceAtomSet<'alloc>>>;
     fn check_labelled_statement(
         &mut self,
@@ -19,23 +19,25 @@ pub trait EarlyErrorChecker<'alloc> {
         end_label_offset: usize,
     ) -> Result<'alloc, ()> {
         let label = self
-            .context_metadata()
+            .context_metadata_mut()
             .find_label_at_offset(start_label_offset)
             .unwrap();
 
         let context = LabelledStatementEarlyErrorsContext::new(name, label.kind);
-        let next_label_index = self.context_metadata().find_first_label(end_label_offset);
-        for info in self.context_metadata().labels_from(next_label_index) {
+        let next_label_index = self
+            .context_metadata_mut()
+            .find_first_label(end_label_offset);
+        for info in self.context_metadata_mut().labels_from(next_label_index) {
             context.check_duplicate_label(info.name)?;
         }
 
         let break_or_continue_index = self
-            .context_metadata()
+            .context_metadata_mut()
             .find_first_break_or_continue(start_label_offset);
 
         self.check_unhandled_continue(context, break_or_continue_index)?;
 
-        self.context_metadata()
+        self.context_metadata_mut()
             .pop_labelled_breaks_and_continues_from_index(break_or_continue_index, name);
         Ok(())
     }
@@ -45,7 +47,7 @@ pub trait EarlyErrorChecker<'alloc> {
         context: LabelledStatementEarlyErrorsContext,
         index: BreakOrContinueIndex,
     ) -> Result<'alloc, ()> {
-        for info in self.context_metadata().breaks_and_continues_from(index) {
+        for info in self.context_metadata_mut().breaks_and_continues_from(index) {
             context.check_labelled_continue_to_non_loop(info)?;
         }
 
@@ -60,8 +62,10 @@ pub trait EarlyErrorChecker<'alloc> {
     where
         T: ControlEarlyErrorsContext,
     {
-        let index = self.context_metadata().find_first_break_or_continue(offset);
-        if let Some(info) = self.context_metadata().find_break_or_continue_at(index) {
+        let index = self
+            .context_metadata_mut()
+            .find_first_break_or_continue(offset);
+        if let Some(info) = self.context_metadata_mut().find_break_or_continue_at(index) {
             context.on_unhandled_break_or_continue(info)?;
         }
 
@@ -89,12 +93,9 @@ pub trait EarlyErrorChecker<'alloc> {
     //       should contain this information.
     fn is_labelled_function(&self, offset: usize) -> bool {
         // Step 1. If stmt is not a LabelledStatement , return false.
-        if let Some(index) = self
-            .context_metadata_immutable()
-            .find_label_index_at_offset(offset)
-        {
+        if let Some(index) = self.context_metadata().find_label_index_at_offset(offset) {
             // Step 2. Let item be the LabelledItem of stmt.
-            for label in self.context_metadata_immutable().labels_from(index) {
+            for label in self.context_metadata().labels_from(index) {
                 match label.kind {
                     // Step 3. If item is LabelledItem : FunctionDeclaration,
                     // return true.
@@ -117,10 +118,10 @@ pub trait EarlyErrorChecker<'alloc> {
         let mut context = ScriptEarlyErrorsContext::new();
         let index = BindingsIndex { index: 0 };
         self.declare_script_or_function(&mut context, index)?;
-        self.context_metadata().pop_bindings_from(index);
+        self.context_metadata_mut().pop_bindings_from(index);
 
         let label_index = LabelIndex { index: 0 };
-        self.context_metadata().pop_labels_from(label_index);
+        self.context_metadata_mut().pop_labels_from(label_index);
 
         self.check_unhandled_break_or_continue(context, 0)?;
 
@@ -132,10 +133,10 @@ pub trait EarlyErrorChecker<'alloc> {
         let mut context = ModuleEarlyErrorsContext::new();
         let index = BindingsIndex { index: 0 };
         self.declare_script_or_function(&mut context, index)?;
-        self.context_metadata().pop_bindings_from(index);
+        self.context_metadata_mut().pop_bindings_from(index);
 
         let label_index = LabelIndex { index: 0 };
-        self.context_metadata().pop_labels_from(label_index);
+        self.context_metadata_mut().pop_labels_from(label_index);
 
         self.check_unhandled_break_or_continue(context, 0)?;
 
@@ -152,7 +153,7 @@ pub trait EarlyErrorChecker<'alloc> {
     where
         T: LexicalEarlyErrorsContext + VarEarlyErrorsContext,
     {
-        for info in self.context_metadata_immutable().bindings_from(index) {
+        for info in self.context_metadata().bindings_from(index) {
             match info.kind {
                 BindingKind::Var => {
                     context.declare_var(

--- a/crates/generated_parser/src/lib.rs
+++ b/crates/generated_parser/src/lib.rs
@@ -3,6 +3,7 @@
 mod ast_builder;
 mod context_stack;
 mod declaration_kind;
+mod early_error_checker;
 mod early_errors;
 mod error;
 mod parser_tables_generated;


### PR DESCRIPTION
Depends on #504, Draft

This introduces the error checker trait and implements errors related to labels on scripts and modules only. Hopefully this will be useful in the future for Syntax only parsing as well as full parsing. 

There are a few things I am unsure of, namely if accessing data off the `ast_builder` struct from the trait is a good idea. 